### PR TITLE
Add TryNano under faucets section

### DIFF
--- a/docs/getting-started-users/acquiring.md
+++ b/docs/getting-started-users/acquiring.md
@@ -12,6 +12,7 @@ Get some free Nano from community maintained and donated faucets to test it out.
 
 - <a href="https://nano-faucet.org/" target="_blank">nano-faucet.org</a>
 - <a href="https://www.freenanofaucet.com/" target="_blank">freenanofaucet.com</a>
+- <a href="https://www.trynano.io/" target="_blank">trynano.io</a>
 - <a href="https://tetraloom.com/nano/" target="_blank">tetraloom.com</a>
 - <a href="http://nendlyy5734pdfflygapdayez6dcorodcio72jwfvaux4fsrzyh7rzqd.onion/faucet/" target="_blank">nendlyy5734...yh7rzqd.onion</a> (TOR)
 - <a href="https://apollonano.com/" target="_blank">apollonano.com</a>


### PR DESCRIPTION
As TryNano is now back online, it makes sense to add it to nano.community, alongside the other faucets listed.

Maybe in the future, this can have its own dedicated section under Faucets as it's more so a step-by-step walkthrough using Nano rather than just a conventional faucet.